### PR TITLE
Fix Windows build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,13 @@ jobs:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.1
       - name: Compile
-        run: msbuild Postal.sln ^
-              /p:Configuration=Release ^
-              /p:Platform=Win32 ^
-              /p:PlatformToolset=v143 ^
-              /p:WindowsTargetPlatformVersion=10.0
+        shell: cmd
+        run: |
+          msbuild Postal.sln ^
+            /p:Configuration=Release ^
+            /p:Platform=Win32 ^
+            /p:PlatformToolset=v143 ^
+            /p:WindowsTargetPlatformVersion=10.0
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- fix Windows MSBuild command by specifying cmd shell

## Testing
- `make clean`
- `make` *(fails: No rule to make target '-lSDL2', needed by 'bin/postal1-x86_64')*

------
https://chatgpt.com/codex/tasks/task_e_685bc41f8678832995602beefeccd17b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Windows build process to improve script formatting and shell specification. No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->