### PR TITLE
Enable arm64 build and update Windows target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,16 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libsdl2-dev libsdl2-mixer-dev
+          sudo apt-get install -y build-essential libsdl2-dev libsdl2-mixer-dev \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: Compile
         run: |
           make clean || true
-          make
+          make ARM64=1
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux-build
+          name: linux-build-arm64
           path: bin/
 
 
@@ -35,7 +36,7 @@ jobs:
         run: |
           msbuild Postal.sln ^
             /p:Configuration=Release ^
-            /p:Platform=Win32 ^
+            /p:Platform=x64 ^
             /p:PlatformToolset=v143 ^
             /p:WindowsTargetPlatformVersion=10.0
       - name: Upload artifact

--- a/makefile
+++ b/makefile
@@ -27,6 +27,15 @@ else ifeq ($(ODROID),1)
   steamworks := false
   CFLAGS += -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard -ftree-vectorize -ffast-math -DODROID
   CLIENTEXE := $(BINDIR)/postal1-arm
+else ifeq ($(ARM64),1)
+  macosx := false
+  CPUARCH := arm64
+  CC := aarch64-linux-gnu-gcc
+  CXX := aarch64-linux-gnu-g++
+  LINKER := aarch64-linux-gnu-g++
+  steamworks := false
+  CFLAGS += -march=armv8-a
+  CLIENTEXE := $(BINDIR)/postal1-arm64
 else ifeq ($(linux_x86),1)
   target := linux_x86
   CFLAGS += -m32
@@ -54,6 +63,13 @@ ifeq ($(strip $(target)),linux_x86_64)
   CC ?= gcc
   CXX ?= g++
   LINKER ?= g++
+endif
+ifeq ($(strip $(target)),linux_arm64)
+  macosx := false
+  CPUARCH := arm64
+  CC ?= aarch64-linux-gnu-gcc
+  CXX ?= aarch64-linux-gnu-g++
+  LINKER ?= aarch64-linux-gnu-g++
 endif
 ifeq ($(strip $(target)),macosx_x86)
   macosx := true
@@ -309,15 +325,15 @@ ifeq ($(strip $(macosx)),true)
 else
   ifeq ($(CPUARCH),arm)
     LIBS += -lSDL2
+  else ifeq ($(CPUARCH),arm64)
+    LIBS += -lSDL2
+  else ifeq ($(CPUARCH),x86_64)
+    LIBS += -lSDL2
   else
-	ifeq ($(CPUARCH),x86_64)
-	  LIBS += -lSDL2
-	else
-	  LIBS += SDL2/libs/linux-x86/libSDL2-2.0.so.0
-	  LDFLAGS += -Wl,-rpath,\$$ORIGIN
-	  STEAMLDFLAGS += steamworks/sdk/redistributable_bin/linux32/libsteam_api.so
-	endif
- endif
+    LIBS += SDL2/libs/linux-x86/libSDL2-2.0.so.0
+    LDFLAGS += -Wl,-rpath,\$$ORIGIN
+    STEAMLDFLAGS += steamworks/sdk/redistributable_bin/linux32/libsteam_api.so
+  endif
 endif
 
 ifeq ($(strip $(steamworks)),true)


### PR DESCRIPTION
## Summary
- add arm64 build rules to the Makefile
- compile arm64 in the GitHub Actions linux job
- build Windows binaries with x64 platform

## Testing
- `make ARM64=1` *(fails: aarch64-linux-gnu-g++ not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bca8689b88329b3332a18ec68982d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for building and releasing ARM64 Linux binaries.
	- Switched Windows builds to produce 64-bit (x64) binaries instead of 32-bit.

- **Chores**
	- Updated build configuration and artifact naming to reflect new architecture targets.
	- Improved cross-compilation setup for Linux ARM64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->